### PR TITLE
Page Selector

### DIFF
--- a/src/routes/dokumente/TOC.svelte
+++ b/src/routes/dokumente/TOC.svelte
@@ -1,9 +1,7 @@
 <script>
-	import { enhance } from '$app/forms';
 	import { goto } from '$app/navigation';
 	import { base } from '$app/paths';
 	import { Accordion } from '@skeletonlabs/skeleton-svelte';
-	import { preventDefault } from 'svelte/legacy';
 
 	let { metaData, accordionStateInit = 'vol1' } = $props();
 	let accordionState = $state([accordionStateInit]);
@@ -58,10 +56,10 @@
 					</p>
 				</div>
 				<div class="pt-5 pl-5">
-					<form class="flex gap-3 items-end" method="POST" use:enhance>
+					<form class="flex gap-3 items-end" onsubmit={(ev)=>{ev.preventDefault(); goto(`${base}/dokumente/vol1?page=${gotoPageNum}`);}}>
 						<span class="text-surface-950-50 text-xl">Zu Seite springen:</span>
 						<input class="w-20 input" type="number" min="0" max="533" bind:value={gotoPageNum} placeholder="1" />
-						<button class="btn shrink h-10 preset-filled-secondary-500" onclick={()=>{goto(`${base}/dokumente/vol1?page=${gotoPageNum}`)}}>Anzeigen</button>
+						<button class="btn shrink h-10 preset-filled-secondary-500" type="submit">Anzeigen</button>
 					</form>
 				</div>
 				<!-- Sitemap -->


### PR DESCRIPTION
Would you solve this the same with enhance? The reasons why I ask are:

- Without enhance the goto() inside a form does not fire. 
- However, enhance requires method="POST", which isn't really needed for a simple redirect...